### PR TITLE
Allows you to use the regular log4j init process and bypass setupLogg…

### DIFF
--- a/celos-server/src/main/java/com/collective/celos/server/Main.java
+++ b/celos-server/src/main/java/com/collective/celos/server/Main.java
@@ -39,7 +39,7 @@ public class Main {
         if(commandLine.getLogStdout()) {
             System.out.println("Logging all messages to stdout");
             Util.setupLoggingToStdout();
-        } else {
+        } else if(System.getProperty("log4j.configuration") == null) {
             Util.setupLogging(commandLine.getLogDir());
         }
 


### PR DESCRIPTION
…ing, just set log4j.configuration to a log4j.properties file as you normally would